### PR TITLE
In gemspec, rely on git-tracked files, blacklisted.

### DIFF
--- a/rutui.gemspec
+++ b/rutui.gemspec
@@ -7,11 +7,7 @@ Gem::Specification.new do |s|
   s.license     = "MIT"
   s.authors     = ["Roman Pramberger"]
   s.email       = 'roman@pramberger.ch'
-  s.files       = [ "lib/rutui.rb", "lib/rutui/ansi.rb", "lib/rutui/pixel.rb",
-            "lib/rutui/input.rb", "lib/rutui/theme.rb", "lib/rutui/objects.rb", 
-            "lib/rutui/screen.rb", "lib/rutui/checkbox.rb", 
-  					"lib/rutui/screenmanager.rb", "lib/rutui/figlet.rb", "lib/rutui/axx.rb", 
-  					"lib/rutui/sprites.rb", "lib/rutui/table.rb", "lib/rutui/textfield.rb"]
+  s.files       = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   s.homepage    = 'http://rubygems.org/gems/rutui'
   s.required_ruby_version = '>= 2.0.0'
 end


### PR DESCRIPTION
This is the approach taken by "bundle new <gem>".
Fixes #2 .
