### PR TITLE
Increase performance of Screen#draw

### DIFF
--- a/lib/rutui/screen.rb
+++ b/lib/rutui/screen.rb
@@ -114,18 +114,18 @@ module RuTui
 			@map.each do |line|
 				line.each do |pixel|
 					if lastpixel != pixel
-						out += RuTui::Ansi.clear_color if lastpixel != 0
+						out << RuTui::Ansi.clear_color if lastpixel != 0
 						if pixel.nil?
-							out += "#{RuTui::Ansi.bg(@default.bg)}#{RuTui::Ansi.fg(@default.fg)}#{@default.symbol}"
+							out << "#{RuTui::Ansi.bg(@default.bg)}#{RuTui::Ansi.fg(@default.fg)}#{@default.symbol}"
 						else
-							out += "#{RuTui::Ansi.bg(pixel.bg)}#{RuTui::Ansi.fg(pixel.fg)}#{pixel.symbol}"
+							out << "#{RuTui::Ansi.bg(pixel.bg)}#{RuTui::Ansi.fg(pixel.fg)}#{pixel.symbol}"
 						end
 						lastpixel = pixel
 					else
 						if pixel.nil?
-							out += @default.symbol
+							out << @default.symbol
 						else
-							out += pixel.symbol
+							out << pixel.symbol
 						end
 					end
 				end


### PR DESCRIPTION
This patch tweaks Screen#draw to use `<<` instead of `+=` for building strings. This avoids the allocation of temporary String objects, which is the main performance bottleneck for drawing to the screen at a high FPS.


Here are benchmark results showing the difference between the two approaches:

```
                  user     system      total        real
draw with +=  0.280000   0.020000   0.300000 (  0.328237)
draw with <<  0.080000   0.000000   0.080000 (  0.085206)
```

I have been using this (awesome!) framework for an interactive debugger, and with this tweak I've been able to go from ~5fps @ 100% cpu to ~20fps @ 30% cpu.
