### PR TITLE
Remove extra character

### DIFF
--- a/lib/rutui/table.rb
+++ b/lib/rutui/table.rb
@@ -109,7 +109,6 @@ module RuTui
 				obj << ascii_table_line if @ascii
 				_obj = []
 				_obj << Pixel.new(@pixel.fg,@bg,"|") if @ascii
-				_obj << nil
 				@cols.each_with_index do |col, index|
 					fg = @pixel.fg
 					fg = @cols[index][:title_color] if !@cols[index].nil? and !@cols[index][:title_color].nil?


### PR DESCRIPTION
This extra character causes the table column titles to have an extra character for the first column. You can see an example of this in the sortable-table example.